### PR TITLE
Add error checking at the byte and packet level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include
+include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -71,13 +72,13 @@ include_directories(include
 
 ## Declare a cpp executable
 # add_executable(xv_11_laser_driver_node src/xv_11_laser_driver_node.cpp)
-add_executable(neato_laser_publisher 
+add_executable(neato_laser_publisher
 	src/neato_laser_publisher.cpp
 	src/xv11_laser.cpp
 )
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-add_dependencies(neato_laser_publisher xv_11_laser_driver_generate_messages_cpp)
+# add_dependencies(neato_laser_publisher xv_11_laser_driver_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(neato_laser_publisher
@@ -138,4 +139,3 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
-

--- a/src/neato_laser_publisher.cpp
+++ b/src/neato_laser_publisher.cpp
@@ -60,8 +60,8 @@ int main(int argc, char **argv)
 
   try {
     xv_11_laser_driver::XV11Laser laser(port, baud_rate, firmware_number, io);
-    ros::Publisher laser_pub = n.advertise<sensor_msgs::LaserScan>("scan", 1000);
-    ros::Publisher motor_pub = n.advertise<std_msgs::UInt16>("rpms", 1000);
+    ros::Publisher laser_pub = n.advertise<sensor_msgs::LaserScan>("scan", 10);
+    ros::Publisher motor_pub = n.advertise<std_msgs::UInt16>("rpms", 10);
 
     while (ros::ok()) {
       sensor_msgs::LaserScan::Ptr scan(new sensor_msgs::LaserScan);
@@ -76,7 +76,9 @@ int main(int argc, char **argv)
     laser.close();
     return 0;
   } catch (boost::system::system_error ex) {
-    ROS_ERROR("Error instantiating laser object. Are you sure you have the correct port and baud rate? Error was %s", ex.what());
-    return -1;
+      ROS_ERROR("Error instantiating laser object. "
+                "Are you sure you have the correct port and baud rate? "
+                "Error was %s", ex.what());
+      return -1;
   }
 }

--- a/src/neato_laser_publisher.cpp
+++ b/src/neato_laser_publisher.cpp
@@ -76,9 +76,9 @@ int main(int argc, char **argv)
     laser.close();
     return 0;
   } catch (boost::system::system_error ex) {
-      ROS_ERROR("Error instantiating laser object. "
-                "Are you sure you have the correct port and baud rate? "
-                "Error was %s", ex.what());
-      return -1;
+    ROS_ERROR("Error instantiating laser object. "
+              "Are you sure you have the correct port and baud rate? "
+              "The error was: %s", ex.what());
+    return -1;
   }
 }

--- a/src/xv11_laser.cpp
+++ b/src/xv11_laser.cpp
@@ -35,6 +35,7 @@
 #include <xv_11_laser_driver/xv11_laser.h>
 
 namespace xv_11_laser_driver {
+
   XV11Laser::XV11Laser(const std::string& port, uint32_t baud_rate, uint32_t firmware, boost::asio::io_service& io): port_(port),
   baud_rate_(baud_rate), firmware_(firmware), shutting_down_(false), serial_(io, port_) {
     serial_.set_option(boost::asio::serial_port_base::baud_rate(baud_rate_));
@@ -103,89 +104,135 @@ namespace xv_11_laser_driver {
       }
     }
       }
-    } else if(firmware_ == 2) { // This is for the newer driver that outputs packets 4 pings at a time
-      boost::array<uint8_t, 1980> raw_bytes;
-      uint8_t good_sets = 0;
+
+    // This is for the newer firmware that outputs packets with 4 readings each
+    } else if (firmware_ == 2) {
+
+      const float ONE_DEGREE = (2.0 * M_PI / 360.0);
+
+      scan->angle_min = 0.0;
+      scan->angle_max = 2.0 * M_PI - ONE_DEGREE; // No double-count
+      scan->angle_increment = ONE_DEGREE;
+      scan->range_min = 0.15;
+      scan->range_max = 5.0;
+      scan->ranges.resize(360);
+      scan->intensities.resize(360);
+
+      const uint8_t HEADER_BYTE = 0xFA;
+      const uint8_t FIRST_INDEX_BYTE = 0xA0;
+
+      boost::array<uint8_t, 2100> raw_bytes; // If no errors, it would be 1980
+
+      int angle; // The index of the scan.ranges array. Ranges from 0 to 359
+      uint8_t packet_index; // Second byte of a packet. Ranges from 0 to 89
+      bool good_packet;
+      uint8_t good_packets = 0; // Number of good packets. Ranges from 0 to 90.
       uint32_t motor_speed = 0;
       rpms = 0;
-      int index;
+
       while (!shutting_down_ && !got_scan) {
-          // Wait until first data sync of frame: 0xFA, 0xA0
-          boost::asio::read(serial_, boost::asio::buffer(&raw_bytes[start_count],1));
-          if(start_count == 0) {
-              if(raw_bytes[start_count] == 0xFA) {
-                  start_count = 1;
-              }
-          } else if(start_count == 1) {
-              if(raw_bytes[start_count] == 0xA0) {
-                  start_count = 0;
 
-                  // Now that entire start sequence has been found, read in the rest of the message
-                  got_scan = true;
+        // Wait until first data sync of frame, i.e., 0xFA, 0xA0
+        boost::asio::read(serial_, boost::asio::buffer(&raw_bytes[start_count], 1));
 
-                  boost::asio::read(serial_, boost::asio::buffer(&raw_bytes[2], 1978));
+        if (start_count == 0) {
+          if (raw_bytes[start_count] == HEADER_BYTE) {
+            start_count = 1;
+          }
+        } else if (start_count == 1) {
+          if (raw_bytes[start_count] == FIRST_INDEX_BYTE) {
+            start_count = 0;
 
-                  const float ONE_DEGREE = (2.0*M_PI/360.0);
+            // Now that the entire start sequence has been found,
+            // start reading packets until the laser scan is complete
+            got_scan = true;
 
-                  scan->angle_min = 0.0;
-                  scan->angle_max = 2.0 * M_PI - ONE_DEGREE; // No double-count
-                  scan->angle_increment = ONE_DEGREE;
-                  scan->range_min = 0.15;
-                  scan->range_max = 5.0;
-                  scan->ranges.resize(360);
-                  scan->intensities.resize(360);
+            boost::asio::read(serial_, boost::asio::buffer(&raw_bytes[2], 1978));
 
-                  //read data in sets of 4
-                  for(uint16_t i = 0; i < raw_bytes.size(); i=i+22) { // 90 packets per revolution
+            uint16_t i = 0; // Iterates over the raw byte stream
 
-                      if(raw_bytes[i] == 0xFA && raw_bytes[i+1] == (0xA0+i/22)) { // && CRC checksum
-                        good_sets++;
-                        motor_speed += (raw_bytes[i+3] << 8) + raw_bytes[i+2]; //accumulate count for avg. time increment
-                        rpms=(raw_bytes[i+3]<<8|raw_bytes[i+2])/64;
+            while (!shutting_down_ && (i + 22 < raw_bytes.size())) {
 
-                        for(uint16_t j = i+4; j < i+20; j=j+4) { // 4 measurements per packet
-                            index = (4*i)/22 + (j-4-i)/4;
-                            // Four bytes per reading
-                            uint8_t byte0 = raw_bytes[j];
-                            uint8_t byte1 = raw_bytes[j+1];
-                            uint8_t byte2 = raw_bytes[j+2];
-                            uint8_t byte3 = raw_bytes[j+3];
-                            // First two bits of byte1 are status flags
-                            // uint8_t flag1 = (byte1 & 0x80) >> 7;  // No return/max range/too low of reflectivity
-                            // uint8_t flag2 = (byte1 & 0x40) >> 6;  // Object too close, possible poor reading due to proximity kicks in at < 0.6m
-                            // Remaining bits are the range in mm
-                            uint16_t range = ((byte1 & 0x3F)<< 8) + byte0;
-                            // Last two bytes represent the uncertainty or intensity, might also be pixel area of target...
-                            uint16_t intensity = (byte3 << 8) + byte2;
+              packet_index = (raw_bytes[i+1] - FIRST_INDEX_BYTE);
 
-                            scan->ranges[index] = range / 1000.0;
-                            scan->intensities[index] = intensity;
-                        }
+              if (raw_bytes[i] == HEADER_BYTE && packet_index >= 0
+                                              && packet_index < 90) {
 
-                    } else if (raw_bytes[i] == 0xFA && raw_bytes[i+1] == 0xA0) {
-                         std::cout << "\n<-- Unexpected start of new revolution! (0xFA, 0xA0) -->\n\n";
+                // Check whether this seems to be a proper packet of length 22
+                good_packet = true; // Start optimistically
 
-                    } else if (i != 0 && raw_bytes[i+1] == 0xA0) {
-                        std::cout << "\nUnexpected start byte (0xA0) in packet " << (i/22 + 1) << "\n\n";
+                for (uint16_t k = 2; k < 22; k++) {
 
-                    } else {
-                        std::cout << std::showbase      // Show the 0x hex prefix
-                                  << std::internal      // Fill between the prefix and the number
-                                  << std::setfill('0'); // Fill with 0s if less than 4 digits
-
-                        std::cout << "Unexpected start (" << std::hex << std::setw(4)
-                                  << static_cast<int>(raw_bytes[i]) << ") "
-                                  << "or index (" << std::hex << std::setw(4)
-                                  << static_cast<int>(raw_bytes[i+1]) << ") "
-                                  << "in packet " << std::dec << static_cast<int>(i/22 + 1) << "\n";
-                    }
+                  // If there is an unexpected header byte, skip this packet
+                  if (raw_bytes[i+k] == HEADER_BYTE) {
+                    good_packet = false;
+                    i = i + k;
+                    break;
+                  }
                 }
 
-                std::cout << "<-- Good packets for this revolution = "
-                          << static_cast<int>(good_sets) << " / 90 -->\n";
+                if (good_packet) {
+                  // TODO: CRC checksum too before declaring good packet
 
-                scan->time_increment = motor_speed/good_sets/1e8;
+                  good_packets++;
+                  // std::cout << "Good packet starting at i = " << i << "\n";
+
+                  // Accumulate count for average time increment of scan
+                  motor_speed += (raw_bytes[i+3] << 8) + raw_bytes[i+2];
+                  rpms = (raw_bytes[i+3]<<8 | raw_bytes[i+2]) / 64;
+
+                  // Iterate over the 4 measurements of this packet
+                  for (uint16_t j = i+4; j < i+20; j=j+4) {
+
+                    // Calculate the bearing angle (index of ranges)
+                    angle = (4 * packet_index) + (j-4-i)/4;
+
+                    // Four bytes per measurement
+                    uint8_t byte0 = raw_bytes[j];
+                    uint8_t byte1 = raw_bytes[j+1];
+                    uint8_t byte2 = raw_bytes[j+2];
+                    uint8_t byte3 = raw_bytes[j+3];
+
+                    // The first two bits of byte1 are status flags
+                    // No return/max range/too low of reflectivity
+                    uint8_t flag1 = (byte1 & 0x80) >> 7;
+                    // Object too close, possible poor reading due to proximity kicks in at < 0.6m
+                    uint8_t flag2 = (byte1 & 0x40) >> 6;
+
+                    // Remaining bits are the range in mm
+                    uint16_t range = ((byte1 & 0x3F)<< 8) + byte0;
+
+                    // Last two bytes represent the uncertainty or
+                    // intensity, might also be pixel area of target
+                    uint16_t intensity = (byte3 << 8) + byte2;
+
+                    scan->ranges[angle] = range / 1000.0;
+                    scan->intensities[angle] = intensity;
+                  }
+
+                  if (angle == 359) {
+                    break; // Laser scan message is full
+                  } else {
+                    i = i + 22; // Set index to start of next packet
+                  }
+
+                // } else {
+                //   std::cout << "Bad packet starting at i = " << i - k
+                //             << " Found unexpected header byte at i = " << i
+                //             << "\n";
+
+                } // End of packet length (and eventually CRC) check
+
+              } else {
+                i++;
+              } // End of start of packet check
             }
+
+            // std::cout << "<-- Good packets for this revolution = "
+            //           << static_cast<int>(good_packets) << " / 90 -->\n";
+
+            scan->time_increment = motor_speed / good_packets / 1e8;
+          }
         }
       }
     }

--- a/src/xv11_laser.cpp
+++ b/src/xv11_laser.cpp
@@ -41,11 +41,12 @@ namespace xv_11_laser_driver {
   }
 
   void XV11Laser::poll(sensor_msgs::LaserScan::Ptr scan) {
-    uint8_t temp_char;
+
     uint8_t start_count = 0;
     bool got_scan = false;
 
     if(firmware_ == 1){ // This is for the old driver, the one that only outputs speed once per revolution
+      uint8_t temp_char;
       boost::array<uint8_t, 1440> raw_bytes;
       while (!shutting_down_ && !got_scan) {
     // Wait until the start sequence 0x5A, 0xA5, 0x00, 0xC0 comes around
@@ -93,7 +94,7 @@ namespace xv_11_laser_driver {
           uint8_t flag2 = (byte1 & 0x40) >> 6;  // Object too close, possible poor reading due to proximity kicks in at < 0.6m
           // Remaining bits are the range in mm
           uint16_t range = ((byte1 & 0x3F)<< 8) + byte0;
-          // Last two bytes represent the uncertanty or intensity, might also be pixel area of target...
+          // Last two bytes represent the uncertainty or intensity, might also be pixel area of target...
           uint16_t intensity = (byte3 << 8) + byte2;
 
           scan->ranges.push_back(range / 1000.0);
@@ -122,26 +123,27 @@ namespace xv_11_laser_driver {
                   // Now that entire start sequence has been found, read in the rest of the message
                   got_scan = true;
 
-                  boost::asio::read(serial_,boost::asio::buffer(&raw_bytes[2], 1978));
+                  boost::asio::read(serial_, boost::asio::buffer(&raw_bytes[2], 1978));
 
-                  float ONE_DEGREE = (2.0*M_PI/360.0);
+                  const float ONE_DEGREE = (2.0*M_PI/360.0);
 
                   scan->angle_min = 0.0;
                   scan->angle_max = 2.0 * M_PI - ONE_DEGREE; // No double-count
                   scan->angle_increment = ONE_DEGREE;
-                  scan->range_min = 0.06;
+                  scan->range_min = 0.15;
                   scan->range_max = 5.0;
                   scan->ranges.resize(360);
                   scan->intensities.resize(360);
 
                   //read data in sets of 4
-                  for(uint16_t i = 0; i < raw_bytes.size(); i=i+22) {
-                      if(raw_bytes[i] == 0xFA && raw_bytes[i+1] == (0xA0+i/22)) {//&& CRC check
+                  for(uint16_t i = 0; i < raw_bytes.size(); i=i+22) { // 90 packets per revolution
+
+                      if(raw_bytes[i] == 0xFA && raw_bytes[i+1] == (0xA0+i/22)) { // && CRC checksum
                         good_sets++;
                         motor_speed += (raw_bytes[i+3] << 8) + raw_bytes[i+2]; //accumulate count for avg. time increment
                         rpms=(raw_bytes[i+3]<<8|raw_bytes[i+2])/64;
 
-                        for(uint16_t j = i+4; j < i+20; j=j+4) {
+                        for(uint16_t j = i+4; j < i+20; j=j+4) { // 4 measurements per packet
                             index = (4*i)/22 + (j-4-i)/4;
                             // Four bytes per reading
                             uint8_t byte0 = raw_bytes[j];
@@ -153,14 +155,34 @@ namespace xv_11_laser_driver {
                             // uint8_t flag2 = (byte1 & 0x40) >> 6;  // Object too close, possible poor reading due to proximity kicks in at < 0.6m
                             // Remaining bits are the range in mm
                             uint16_t range = ((byte1 & 0x3F)<< 8) + byte0;
-                            // Last two bytes represent the uncertanty or intensity, might also be pixel area of target...
+                            // Last two bytes represent the uncertainty or intensity, might also be pixel area of target...
                             uint16_t intensity = (byte3 << 8) + byte2;
 
                             scan->ranges[index] = range / 1000.0;
                             scan->intensities[index] = intensity;
                         }
+
+                    } else if (raw_bytes[i] == 0xFA && raw_bytes[i+1] == 0xA0) {
+                         std::cout << "\n<-- Unexpected start of new revolution! (0xFA, 0xA0) -->\n\n";
+
+                    } else if (i != 0 && raw_bytes[i+1] == 0xA0) {
+                        std::cout << "\nUnexpected start byte (0xA0) in packet " << (i/22 + 1) << "\n\n";
+
+                    } else {
+                        std::cout << std::showbase      // Show the 0x hex prefix
+                                  << std::internal      // Fill between the prefix and the number
+                                  << std::setfill('0'); // Fill with 0s if less than 4 digits
+
+                        std::cout << "Unexpected start (" << std::hex << std::setw(4)
+                                  << static_cast<int>(raw_bytes[i]) << ") "
+                                  << "or index (" << std::hex << std::setw(4)
+                                  << static_cast<int>(raw_bytes[i+1]) << ") "
+                                  << "in packet " << std::dec << static_cast<int>(i/22 + 1) << "\n";
                     }
                 }
+
+                std::cout << "<-- Good packets for this revolution = "
+                          << static_cast<int>(good_sets) << " / 90 -->\n";
 
                 scan->time_increment = motor_speed/good_sets/1e8;
             }


### PR DESCRIPTION
Changes:
- Increase `range_min` to 15cm from 6cm
- Add the error checking
- Add in-line documentation
- No idea what the original `time_increment` was doing. Added my own.
- Also added `scan_time` calculation. It was left at `0.0` originally.

Testing:
- Tested on BBB3 and a new XV-11 LiDAR.
- I'll test on the robot as well and then merge this PR.
- Looked OK. But before merging, I want to verify that:
  - `time_increment` and `scan_time`don't break anything.
  - That the publisher queue isn't too small now (10 from 1000)
